### PR TITLE
Add string version of build

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,14 @@ npm install -g cordova
 
 ## Usage
 
-After `deviceReady` has fired you'll be able to access a new object in the global scope that contains both the app version and build number.
+After `deviceReady` has fired you'll be able to access a new object in the global scope that contains three version-related properties:
+
+- *version*: string value of the released version number
+- *build*: number value of the build (more useful for Android)
+- *buildString*: string value of the build (more useful for iOS, although also passes the Android build back as a string)
 
 ```javascript
 console.log(AppVersion.version); // e.g. "1.2.3"
 console.log(AppVersion.build); // e.g. 1234
+console.log(AppVersion.buildString); // e.g. "1.2.3b4"
 ```

--- a/www/app-version.js
+++ b/www/app-version.js
@@ -45,6 +45,7 @@ var RareloopAppVersion = function () {
 
             _this.version = info.version;
             _this.build = parseInt(info.build, 10);
+            _this.buildString = info.build;
 
             channel.onCordovaAppVersionReady.fire();
         },function(e) {


### PR DESCRIPTION
iOS has a different mechanism for identifying build info than Android. On Android, it's a number; on iOS, it's using more of the semantic versioning string syntax: https://developer.apple.com/library/content/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html#//apple_ref/doc/uid/20001431-102364

Adding a buildString API allows the full CFBundleVersion string to be passed to the Cordova app, so values like `1.0.0b3` don't get mangled into an integer.
